### PR TITLE
Only add input classes to form fields if they exist.

### DIFF
--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -71,8 +71,9 @@ def render(element, markup_classes):
             template = get_template("bootstrapform/formset.html")
             context = Context({'formset': element, 'classes': markup_classes})
         else:
-            for field in element.visible_fields():
-                add_input_classes(field)
+            if element:
+                for field in element.visible_fields():
+                    add_input_classes(field)
 
             template = get_template("bootstrapform/form.html")
             context = Context({'form': element, 'classes': markup_classes})


### PR DESCRIPTION
I encountered an error when using the generic DeleteView. By default the confirmation form created does not have any input fields. This raise an exception since element was an empty string.
